### PR TITLE
DUNE DAQ work area source patsh added to dbe search path

### DIFF
--- a/scripts/dunedaq_dbe
+++ b/scripts/dunedaq_dbe
@@ -1,0 +1,17 @@
+#!/usr/bin/bash
+
+OKS_GUI_PATH=""
+SOURCE_DIR=${DBT_AREA_ROOT}/sourcecode
+DBT_PACKAGES=$(find -L ${SOURCE_DIR}/ -mindepth 2 -maxdepth 2 -name CMakeLists.txt | sed "s#${SOURCE_DIR}/\(.*\)/CMakeLists.txt#\1#")
+
+echo $DBT_PACKAGES
+for p in ${DBT_PACKAGES}; do
+
+    OKS_GUI_PATH+=":${SOURCE_DIR}/$p" 
+
+done
+
+export OKS_GUI_PATH
+
+echo $OKS_GUI_PATH
+dbe_main ${@:1}

--- a/scripts/dunedaq_dbe
+++ b/scripts/dunedaq_dbe
@@ -4,13 +4,12 @@ OKS_GUI_PATH=""
 SOURCE_DIR=${DBT_AREA_ROOT}/sourcecode
 DBT_PACKAGES=$(find -L ${SOURCE_DIR}/ -mindepth 2 -maxdepth 2 -name CMakeLists.txt | sed "s#${SOURCE_DIR}/\(.*\)/CMakeLists.txt#\1#")
 
-echo $DBT_PACKAGES
 for p in ${DBT_PACKAGES}; do
 
     OKS_GUI_PATH+=":${SOURCE_DIR}/$p" 
 
 done
 
-export OKS_GUI_PATH
+export DUNEDAQ_SHARE_PATH="${OKS_GUI_PATH}:${DUNEDAQ_SHARE_PATH}"
 
 dbe_main ${@:1}

--- a/scripts/dunedaq_dbe
+++ b/scripts/dunedaq_dbe
@@ -13,5 +13,4 @@ done
 
 export OKS_GUI_PATH
 
-echo $OKS_GUI_PATH
 dbe_main ${@:1}

--- a/scripts/dunedaq_schemaeditor
+++ b/scripts/dunedaq_schemaeditor
@@ -13,5 +13,4 @@ done
 
 export OKS_GUI_PATH
 
-echo $OKS_GUI_PATH
-dbe_main ${@:1}
+schemaeditor ${@:1}

--- a/scripts/dunedaq_schemaeditor
+++ b/scripts/dunedaq_schemaeditor
@@ -1,0 +1,17 @@
+#!/usr/bin/bash
+
+OKS_GUI_PATH=""
+SOURCE_DIR=${DBT_AREA_ROOT}/sourcecode
+DBT_PACKAGES=$(find -L ${SOURCE_DIR}/ -mindepth 2 -maxdepth 2 -name CMakeLists.txt | sed "s#${SOURCE_DIR}/\(.*\)/CMakeLists.txt#\1#")
+
+echo $DBT_PACKAGES
+for p in ${DBT_PACKAGES}; do
+
+    OKS_GUI_PATH+=":${SOURCE_DIR}/$p" 
+
+done
+
+export OKS_GUI_PATH
+
+echo $OKS_GUI_PATH
+dbe_main ${@:1}

--- a/scripts/dunedaq_schemaeditor
+++ b/scripts/dunedaq_schemaeditor
@@ -4,13 +4,12 @@ OKS_GUI_PATH=""
 SOURCE_DIR=${DBT_AREA_ROOT}/sourcecode
 DBT_PACKAGES=$(find -L ${SOURCE_DIR}/ -mindepth 2 -maxdepth 2 -name CMakeLists.txt | sed "s#${SOURCE_DIR}/\(.*\)/CMakeLists.txt#\1#")
 
-echo $DBT_PACKAGES
 for p in ${DBT_PACKAGES}; do
 
     OKS_GUI_PATH+=":${SOURCE_DIR}/$p" 
 
 done
 
-export OKS_GUI_PATH
+export DUNEDAQ_SHARE_PATH="${OKS_GUI_PATH}:${DUNEDAQ_SHARE_PATH}"
 
 schemaeditor ${@:1}

--- a/src/internal/MainWindow.cpp
+++ b/src/internal/MainWindow.cpp
@@ -694,6 +694,10 @@ void dbe::MainWindow::LoadDefaultSetting()
 
 QString dbe::MainWindow::find_db_repository_dir()
 {
+    if (confaccessor::dbfullname().isEmpty()) {
+      return "";
+    }
+
     const QStringList& incs =dbe::config::api::get::file::inclusions({confaccessor::dbfullname()});
     for(QString f : allFiles) {
         for(const QString& j : incs) {
@@ -708,6 +712,7 @@ QString dbe::MainWindow::find_db_repository_dir()
 
 void dbe::MainWindow::slot_create_newdb()
 {
+
   CreateDatabaseWidget * CreateDatabaseW = new CreateDatabaseWidget(nullptr, false, find_db_repository_dir());
   CreateDatabaseW->show();
   connect ( CreateDatabaseW, SIGNAL ( CanLoadDatabase ( const QString & ) ), this,

--- a/src/internal/confaccessor.cpp
+++ b/src/internal/confaccessor.cpp
@@ -376,7 +376,7 @@ void dbe::confaccessor::init()
 
   confaccessor::ref().coreconfig = new ui::config::info ( full_path_names );
 
-  setenv ( "DUNEDAQ_SHARE_PATH", TDAQ_VARIABLE.toStdString().c_str(), 1 );
+  // setenv ( "DUNEDAQ_SHARE_PATH", TDAQ_VARIABLE.toStdString().c_str(), 1 );
 }
 
 QList<QStringList> dbe::confaccessor::GetIncludedFileCache() const


### PR DESCRIPTION
`schema` and `config` paths are added to the dbe search path to capture modifications to schema and database files contained in `sourcecode`.
Also: fixed `dbe` crashing when creating a new DB and no previous configuration is loaded.