### PR TITLE
Workaround for issue creating object from first class in list

### DIFF
--- a/src/widgets/ObjectCreator.cpp
+++ b/src/widgets/ObjectCreator.cpp
@@ -73,8 +73,11 @@ dbe::ObjectCreator::ObjectCreator ( dunedaq::conffwk::class_t const & cinfo, QWi
   BuildContextMenu();
 
   int index = ui->ComboBoxClass->findText ( cname );
-
-  ui->ComboBoxClass->setCurrentIndex ( index );
+  ui->ComboBoxClass->setCurrentIndex ( 1 );  // If index is 0 somehow this doesnt work
+  ui->ComboBoxClass->setCurrentIndex ( index ); // Now set it to the right value posssibly 0
+  // std::cout << "index=" << index
+  //           << " ui->ComboBoxClass->currentIndex=" << ui->ComboBoxClass->currentIndex()
+  //           << " valid=" << ui->ComboBoxClass->IsValid() << "\n";
   setup_editor();
   ui->ComboBoxClass->setEditText ( cname );
 

--- a/src/widgets/ObjectCreator.cpp
+++ b/src/widgets/ObjectCreator.cpp
@@ -75,9 +75,6 @@ dbe::ObjectCreator::ObjectCreator ( dunedaq::conffwk::class_t const & cinfo, QWi
   int index = ui->ComboBoxClass->findText ( cname );
   ui->ComboBoxClass->setCurrentIndex ( 1 );  // If index is 0 somehow this doesnt work
   ui->ComboBoxClass->setCurrentIndex ( index ); // Now set it to the right value posssibly 0
-  // std::cout << "index=" << index
-  //           << " ui->ComboBoxClass->currentIndex=" << ui->ComboBoxClass->currentIndex()
-  //           << " valid=" << ui->ComboBoxClass->IsValid() << "\n";
   setup_editor();
   ui->ComboBoxClass->setEditText ( cname );
 


### PR DESCRIPTION
This solves issue https://github.com/DUNE-DAQ/dbe/issues/31 by first setting currentIndex to 1 before setting it to the correct value as setting 0 didn't have the desired side effect of setting Valid to true!!