### PR TITLE
Gcrone/multi arrow

### DIFF
--- a/apps/SchemaEditor/SchemaGraphicSegmentedArrow.cpp
+++ b/apps/SchemaEditor/SchemaGraphicSegmentedArrow.cpp
@@ -85,22 +85,50 @@ void SchemaGraphicSegmentedArrow::UpdatePosition()
 
   qreal xoffset;
   qreal yoffset;
-  if (m_start_item->boundingRect().x() > m_end_item->boundingRect().x()) {
-    xoffset = m_connection_count*20.0;
+  const qreal factor = 18.0;
+  if (m_start_item->boundingRect().x() < m_end_item->boundingRect().x()) {
+    xoffset = m_connection_count*factor;
   }
   else {
-    xoffset = m_connection_count*-20.0;
+    xoffset = m_connection_count*-factor;
   }
-  if (m_start_item->boundingRect().y() > m_end_item->boundingRect().y()) {
-    yoffset = m_connection_count*20.0;
-  }
-  else {
-    yoffset = m_connection_count*-20.0;
-  }
-  QPointF offset(xoffset, yoffset);
 
-  QLineF center_line ( m_start_item->mapToScene ( m_start_item->boundingRect().center()+offset ),
-                      m_end_item->mapToScene ( m_end_item->boundingRect().center()+offset ) );
+  if (m_start_item->boundingRect().y() > m_end_item->boundingRect().y()) {
+    yoffset = m_connection_count*factor;
+  }
+  else {
+    yoffset = m_connection_count*-factor;
+  }
+
+  auto maxy_start_offset = m_start_item->boundingRect().height() / 2;
+  QPointF start_offset(xoffset, yoffset);
+  int max_con_start = m_start_item->boundingRect().height() / factor;
+  if (abs(yoffset) > maxy_start_offset) {
+    if (m_connection_count < max_con_start) {
+      auto sign = yoffset/yoffset;
+      start_offset.setY((m_connection_count - max_con_start/2) * sign * factor);
+    }
+    else {
+      start_offset.setY(0.0);
+    }
+  }
+  QPointF end_offset(xoffset, yoffset);
+  // if (m_end_item->boundingRect().height()/2.0 < abs(yoffset)) {
+  auto maxy_end_offset = m_end_item->boundingRect().height() / 2;
+  int max_con_end = m_end_item->boundingRect().height() / factor;
+  if (abs(yoffset) > maxy_end_offset) {
+    if (m_connection_count < max_con_end) {
+      auto sign = yoffset/yoffset;
+      yoffset = (m_connection_count - max_con_end/2) * sign * factor;
+      end_offset.setY(yoffset);
+    }
+    else {
+      end_offset.setY(0.0);
+    }
+  }
+
+  QLineF center_line ( m_start_item->mapToScene ( m_start_item->boundingRect().center()+start_offset ),
+                      m_end_item->mapToScene ( m_end_item->boundingRect().center()+end_offset ) );
   QPolygonF start_polygon = QPolygonF ( m_start_item->boundingRect() );
   QPolygonF end_polygon = QPolygonF ( m_end_item->boundingRect() );
   QPointF intersect_point_start, intersect_point_end;

--- a/apps/SchemaEditor/SchemaGraphicSegmentedArrow.cpp
+++ b/apps/SchemaEditor/SchemaGraphicSegmentedArrow.cpp
@@ -1,9 +1,14 @@
 /// Including QT Headers
 #include <QPainter>
 #include <QPen>
+#include <QToolTip>
 /// Including Schema Editor
 #include "dbe/SchemaGraphicSegmentedArrow.hpp"
 #include "dbe/SchemaKernelWrapper.hpp"
+
+/// Including Oks Headers
+#include "oks/class.hpp"
+
 /// Including C++ Headers
 #include <cmath>
 
@@ -26,16 +31,33 @@ SchemaGraphicSegmentedArrow::SchemaGraphicSegmentedArrow ( SchemaGraphicObject *
     LastDegree ( 0 ),
     LastRotation ( 0 )
 {
+  if (!is_inheritance) {
+    setAcceptHoverEvents(true);
+  }
   //setPen(QPen(Qt::black,2,Qt::SolidLine,Qt::RoundCap,Qt::RoundJoin));
   setFlag ( ItemIsSelectable, true );
   m_default_color = QColor ( 0x1e1b18 );
-  m_label_font = QFont( "Helvetica [Cronyx]", 10);
+  m_label_font = QFont( "Helvetica [Cronyx]", 9);
   m_arrow_size = 20;
 
 }
 
 SchemaGraphicSegmentedArrow::~SchemaGraphicSegmentedArrow()
 {
+}
+
+void dbse::SchemaGraphicSegmentedArrow::hoverEnterEvent ( QGraphicsSceneHoverEvent* he) {
+  if (!m_name.isEmpty()) {
+    auto info = m_start_item->GetClass();
+    
+    auto rel = info->find_relationship(m_name.toStdString());
+    
+    QToolTip::showText( he->screenPos(),
+                        QString::fromStdString(rel->get_description()) );
+  }
+}
+void dbse::SchemaGraphicSegmentedArrow::hoverLeaveEvent ( QGraphicsSceneHoverEvent* he) {
+  QToolTip::hideText();
 }
 
 QRectF SchemaGraphicSegmentedArrow::boundingRect() const
@@ -182,8 +204,8 @@ void SchemaGraphicSegmentedArrow::UpdatePosition()
   cardinality_br.translate(-cardinality_br.width()/2, cardinality_br.height()/2);
 
 
-  qreal label_x_padding = 0;
-  qreal label_y_padding = 0;
+  qreal label_x_padding = 2;
+  qreal label_y_padding = -2;
   qreal card_x_padding = 20;
   qreal card_y_padding = 0;
 

--- a/apps/SchemaEditor/SchemaGraphicSegmentedArrow.cpp
+++ b/apps/SchemaEditor/SchemaGraphicSegmentedArrow.cpp
@@ -93,7 +93,7 @@ void SchemaGraphicSegmentedArrow::UpdatePosition()
     xoffset = m_connection_count*-factor;
   }
 
-  if (m_start_item->boundingRect().y() > m_end_item->boundingRect().y()) {
+  if (m_start_item->boundingRect().y() < m_end_item->boundingRect().y()) {
     yoffset = m_connection_count*factor;
   }
   else {
@@ -112,6 +112,7 @@ void SchemaGraphicSegmentedArrow::UpdatePosition()
       start_offset.setY(0.0);
     }
   }
+
   QPointF end_offset(xoffset, yoffset);
   // if (m_end_item->boundingRect().height()/2.0 < abs(yoffset)) {
   auto maxy_end_offset = m_end_item->boundingRect().height() / 2;
@@ -179,9 +180,9 @@ void SchemaGraphicSegmentedArrow::UpdatePosition()
 
 
   qreal label_x_padding = 0;
-  qreal label_y_padding = 1;
-  qreal card_x_padding = 10;
-  qreal card_y_padding = 1;
+  qreal label_y_padding = 0;
+  qreal card_x_padding = 20;
+  qreal card_y_padding = 0;
 
   QPainterPath path( intersect_point_start );
 

--- a/apps/SchemaEditor/SchemaGraphicSegmentedArrow.cpp
+++ b/apps/SchemaEditor/SchemaGraphicSegmentedArrow.cpp
@@ -82,8 +82,25 @@ void SchemaGraphicSegmentedArrow::UpdatePosition()
     {0.,0., 0, -1.}, // down
     {0.,0., -1., 0.}, // left
   };
-  QLineF center_line ( m_start_item->mapToScene ( m_start_item->boundingRect().center() ),
-                      m_end_item->mapToScene ( m_end_item->boundingRect().center() ) );
+
+  qreal xoffset;
+  qreal yoffset;
+  if (m_start_item->boundingRect().x() > m_end_item->boundingRect().x()) {
+    xoffset = m_connection_count*20.0;
+  }
+  else {
+    xoffset = m_connection_count*-20.0;
+  }
+  if (m_start_item->boundingRect().y() > m_end_item->boundingRect().y()) {
+    yoffset = m_connection_count*20.0;
+  }
+  else {
+    yoffset = m_connection_count*-20.0;
+  }
+  QPointF offset(xoffset, yoffset);
+
+  QLineF center_line ( m_start_item->mapToScene ( m_start_item->boundingRect().center()+offset ),
+                      m_end_item->mapToScene ( m_end_item->boundingRect().center()+offset ) );
   QPolygonF start_polygon = QPolygonF ( m_start_item->boundingRect() );
   QPolygonF end_polygon = QPolygonF ( m_end_item->boundingRect() );
   QPointF intersect_point_start, intersect_point_end;
@@ -138,18 +155,12 @@ void SchemaGraphicSegmentedArrow::UpdatePosition()
   qreal card_x_padding = 10;
   qreal card_y_padding = 1;
 
-  qreal xoffset = m_connection_count*25.0;
-  qreal yoffset = m_connection_count*25.0;
-  QPointF end_offset;
-
   QPainterPath path( intersect_point_start );
 
   if ((intersect_norm_start.dx() == 0) && (intersect_norm_end.dx() == 0)) {
     // Three segments, starting and ending vertically
-    end_offset.setX(xoffset);
-    direct_line.translate(xoffset, 0.0);
-    QPointF wp1 = QPointF(direct_line.x1(), direct_line.center().y()+yoffset);
-    QPointF wp2 = QPointF(direct_line.x2(), direct_line.center().y()+yoffset);
+    QPointF wp1 = QPointF(direct_line.x1(), direct_line.center().y());
+    QPointF wp2 = QPointF(direct_line.x2(), direct_line.center().y());
     path.moveTo(direct_line.x1(), direct_line.y1());
     path.lineTo(wp1);
     path.lineTo(wp2);
@@ -171,10 +182,8 @@ void SchemaGraphicSegmentedArrow::UpdatePosition()
 
   } else if ((intersect_norm_start.dy() == 0) && (intersect_norm_end.dy() == 0)) {
     // Three segments, starting and ending horizontally
-    end_offset.setY(yoffset);
-    direct_line.translate(0.0, yoffset);
-    QPointF wp1 = QPointF(direct_line.center().x()+xoffset, direct_line.y1());
-    QPointF wp2 = QPointF(direct_line.center().x()+xoffset, direct_line.y2());
+    QPointF wp1 = QPointF(direct_line.center().x(), direct_line.y1());
+    QPointF wp2 = QPointF(direct_line.center().x(), direct_line.y2());
 
     path.moveTo(direct_line.x1(), direct_line.y1());
     path.lineTo(wp1);
@@ -196,9 +205,7 @@ void SchemaGraphicSegmentedArrow::UpdatePosition()
 
   } else if (intersect_norm_start.dx() == 0) {
     // Two segments, starting vertically, ending horizontally
-    end_offset.setY(yoffset);
-    direct_line.translate(xoffset, 0.0);
-    QPointF wp1 = QPointF(direct_line.x1(), direct_line.y2()+yoffset);
+    QPointF wp1 = QPointF(direct_line.x1(), direct_line.y2());
 
     path.moveTo(direct_line.x1(), direct_line.y1());
     path.lineTo(wp1);
@@ -206,21 +213,17 @@ void SchemaGraphicSegmentedArrow::UpdatePosition()
     label_br.translate( wp1 
       + QPointF(
         (direct_line.dx() > 0 ? 1 : -1) * (label_x_padding+label_br.width()/2), 
-        (direct_line.dy() < 0 ? 1 : -1) * (label_br.height()+label_y_padding
-                                           + yoffset)
+        (direct_line.dy() < 0 ? 1 : -1) * (label_br.height()+label_y_padding)
         )
     );
     cardinality_br.translate( intersect_point_start
       + QPointF(
         (direct_line.dx() < 0 ? 1 : -1) * (card_x_padding+cardinality_br.width()/2), 
-        (direct_line.dy() > 0 ? 1 : -1) * (cardinality_br.height()+card_y_padding
-                                           + yoffset)
+        (direct_line.dy() > 0 ? 1 : -1) * (cardinality_br.height()+card_y_padding)
       )
     );
 
   } else if (intersect_norm_start.dy() == 0) {
-    end_offset.setY(yoffset);
-    direct_line.translate(0.0, yoffset);
     QPointF wp1 = QPointF(direct_line.x2(), direct_line.y1() );
     path.moveTo(direct_line.x1(), direct_line.y1());
 
@@ -242,7 +245,6 @@ void SchemaGraphicSegmentedArrow::UpdatePosition()
 
   }
 
-  intersect_point_end += end_offset;
   path.lineTo( intersect_point_end );
   setPath(path);
   

--- a/apps/SchemaEditor/SchemaGraphicSegmentedArrow.cpp
+++ b/apps/SchemaEditor/SchemaGraphicSegmentedArrow.cpp
@@ -85,48 +85,24 @@ void SchemaGraphicSegmentedArrow::UpdatePosition()
 
   qreal xoffset;
   qreal yoffset;
-  const qreal factor = 18.0;
+  const qreal xfactor = 23.0;
+  const qreal yfactor = 17.0;
   if (m_start_item->boundingRect().x() < m_end_item->boundingRect().x()) {
-    xoffset = m_connection_count*factor;
+    xoffset = m_connection_count*xfactor;
   }
   else {
-    xoffset = m_connection_count*-factor;
+    xoffset = m_connection_count*-xfactor;
   }
 
-  if (m_start_item->boundingRect().y() < m_end_item->boundingRect().y()) {
-    yoffset = m_connection_count*factor;
+  if (m_start_item->boundingRect().y() > m_end_item->boundingRect().y()) {
+    yoffset = m_connection_count*yfactor;
   }
   else {
-    yoffset = m_connection_count*-factor;
+    yoffset = m_connection_count*-yfactor;
   }
 
-  auto maxy_start_offset = m_start_item->boundingRect().height() / 2;
   QPointF start_offset(xoffset, yoffset);
-  int max_con_start = m_start_item->boundingRect().height() / factor;
-  if (abs(yoffset) > maxy_start_offset) {
-    if (m_connection_count < max_con_start) {
-      auto sign = yoffset/yoffset;
-      start_offset.setY((m_connection_count - max_con_start/2) * sign * factor);
-    }
-    else {
-      start_offset.setY(0.0);
-    }
-  }
-
   QPointF end_offset(xoffset, yoffset);
-  // if (m_end_item->boundingRect().height()/2.0 < abs(yoffset)) {
-  auto maxy_end_offset = m_end_item->boundingRect().height() / 2;
-  int max_con_end = m_end_item->boundingRect().height() / factor;
-  if (abs(yoffset) > maxy_end_offset) {
-    if (m_connection_count < max_con_end) {
-      auto sign = yoffset/yoffset;
-      yoffset = (m_connection_count - max_con_end/2) * sign * factor;
-      end_offset.setY(yoffset);
-    }
-    else {
-      end_offset.setY(0.0);
-    }
-  }
 
   QLineF center_line ( m_start_item->mapToScene ( m_start_item->boundingRect().center()+start_offset ),
                       m_end_item->mapToScene ( m_end_item->boundingRect().center()+end_offset ) );
@@ -137,6 +113,7 @@ void SchemaGraphicSegmentedArrow::UpdatePosition()
 
   // Iterate on the sides starting from top-left
   QPointF p1 = end_polygon.first() + m_end_item->pos(), p2;
+  QPointF end_sp;
   for ( int i = 1; i < end_polygon.count(); ++i )
   {
 
@@ -145,6 +122,17 @@ void SchemaGraphicSegmentedArrow::UpdatePosition()
     QLineF::IntersectType intersect_type = item_side.intersects ( center_line, &intersect_point_end );
 
     if ( intersect_type == QLineF::BoundedIntersection ) {
+      switch (i) {
+      case 1:
+      case 3: end_sp=QPointF {m_end_item->pos().x()+m_end_item->boundingRect().width() / 2+xoffset,
+        intersect_point_end.y()};
+        break;
+
+      case 2:
+      case 4: end_sp={intersect_point_end.x(),
+          m_end_item->pos().y()+m_end_item->boundingRect().height() / 2+yoffset};
+        break;
+      }
       intersect_norm_end = norms[i-1];
       break;
     }
@@ -153,14 +141,29 @@ void SchemaGraphicSegmentedArrow::UpdatePosition()
   }
 
   p1 = start_polygon.first() + m_start_item->pos();
+  QPointF start_sp;
   for ( int i = 1; i < start_polygon.count(); ++i )
   {
     p2 = start_polygon.at ( i ) + m_start_item->pos();
     QLineF item_side = QLineF ( p1, p2 );
     QLineF::IntersectType intersect_type = item_side.intersects ( center_line,
                                                                &intersect_point_start );
-
     if ( intersect_type == QLineF::BoundedIntersection ) {
+      switch (i) {
+      case 1:
+        start_sp=QPointF {m_start_item->pos().x() + (m_start_item->boundingRect().width() / 2) + xoffset,
+        intersect_point_start.y()};
+        break;
+      case 3:
+        start_sp=QPointF {m_start_item->pos().x() + (m_start_item->boundingRect().width() / 2) - xoffset,
+        intersect_point_start.y()};
+        break;
+
+      case 2:
+      case 4: start_sp={intersect_point_start.x(),
+          m_start_item->pos().y()+m_start_item->boundingRect().height() / 2+yoffset};
+        break;
+      }
       intersect_norm_start = norms[i-1];
       break;
     }
@@ -168,7 +171,7 @@ void SchemaGraphicSegmentedArrow::UpdatePosition()
     p1 = p2;
   }
 
-  QLineF direct_line(intersect_point_start, intersect_point_end);
+  QLineF direct_line(start_sp, end_sp);
   auto label_br = QRectF(QFontMetrics ( m_label_font ).boundingRect ( m_name ));
   // Center rectangle on origin
   label_br.translate(-label_br.width()/2, label_br.height()/2);
@@ -188,8 +191,10 @@ void SchemaGraphicSegmentedArrow::UpdatePosition()
 
   if ((intersect_norm_start.dx() == 0) && (intersect_norm_end.dx() == 0)) {
     // Three segments, starting and ending vertically
-    QPointF wp1 = QPointF(direct_line.x1(), direct_line.center().y());
-    QPointF wp2 = QPointF(direct_line.x2(), direct_line.center().y());
+    QPointF wp1 = QPointF(direct_line.x1(),
+                          direct_line.center().y()+yoffset);
+    QPointF wp2 = QPointF(direct_line.x2(),
+                          direct_line.center().y()+yoffset);
     path.moveTo(direct_line.x1(), direct_line.y1());
     path.lineTo(wp1);
     path.lineTo(wp2);
@@ -211,8 +216,10 @@ void SchemaGraphicSegmentedArrow::UpdatePosition()
 
   } else if ((intersect_norm_start.dy() == 0) && (intersect_norm_end.dy() == 0)) {
     // Three segments, starting and ending horizontally
-    QPointF wp1 = QPointF(direct_line.center().x(), direct_line.y1());
-    QPointF wp2 = QPointF(direct_line.center().x(), direct_line.y2());
+    QPointF wp1 = QPointF(direct_line.center().x()-xoffset,
+                          direct_line.y1());
+    QPointF wp2 = QPointF(direct_line.center().x()-xoffset,
+                          direct_line.y2());
 
     path.moveTo(direct_line.x1(), direct_line.y1());
     path.lineTo(wp1);
@@ -253,11 +260,12 @@ void SchemaGraphicSegmentedArrow::UpdatePosition()
     );
 
   } else if (intersect_norm_start.dy() == 0) {
+    // Two segments, starting horizontally, ending vertically
     QPointF wp1 = QPointF(direct_line.x2(), direct_line.y1() );
     path.moveTo(direct_line.x1(), direct_line.y1());
 
     path.lineTo(wp1);
-    path.translate (0, + m_connection_count*10.0);
+
 
     label_br.translate( wp1 
       + QPointF(
@@ -274,7 +282,7 @@ void SchemaGraphicSegmentedArrow::UpdatePosition()
 
   }
 
-  path.lineTo( intersect_point_end );
+  path.lineTo( end_sp );
   setPath(path);
   
   m_rel_label_br = label_br;

--- a/apps/SchemaEditor/SchemaGraphicsScene.cpp
+++ b/apps/SchemaEditor/SchemaGraphicsScene.cpp
@@ -225,14 +225,15 @@ QStringList dbse::SchemaGraphicsScene::AddItemsToScene (
       ClassInfo->direct_relationships();
     const std::list<std::string *> * DirectSuperClassesList = ClassInfo->direct_super_classes();
 
-    int arrow_num=0;
+    std::map<std::string, unsigned int> arrow_count;
+
     //// PLotting relationships
     if ( DirectRelationshipList != nullptr )
     {
       for ( OksRelationship * ClassRelationship : * ( DirectRelationshipList ) )
       {
-        QString RelationshipClassType = QString::fromStdString (
-                                          ClassRelationship->get_class_type()->get_name() );
+        auto rct = ClassRelationship->get_class_type()->get_name();
+        QString RelationshipClassType = QString::fromStdString (rct);
 
         if ( ItemMap.contains ( RelationshipClassType ) ) //&& !ItemMap[ClassName]->HasArrow (
           //ItemMap[RelationshipClassType] ) )
@@ -241,7 +242,7 @@ QStringList dbse::SchemaGraphicsScene::AddItemsToScene (
             KernelWrapper::GetInstance().GetCardinalityStringRelationship ( ClassRelationship ) + " ";
           SchemaGraphicSegmentedArrow * NewArrow = new SchemaGraphicSegmentedArrow (
             ItemMap[ClassName], ItemMap[RelationshipClassType],
-            arrow_num,
+            arrow_count[rct],
             false,
             ClassRelationship->get_is_composite(),
             QString::fromStdString ( ClassRelationship->get_name() ), SchemaCardinality );
@@ -251,7 +252,7 @@ QStringList dbse::SchemaGraphicsScene::AddItemsToScene (
           //NewArrow->SetLabelScene(this);
           NewArrow->setZValue ( -1000.0 );
           NewArrow->UpdatePosition();
-          arrow_num++;
+          arrow_count[rct]++;
         }
       }
     }
@@ -269,7 +270,7 @@ QStringList dbse::SchemaGraphicsScene::AddItemsToScene (
           SchemaGraphicSegmentedArrow * NewArrow = new SchemaGraphicSegmentedArrow (
             ItemMap[ClassName],
             ItemMap[SuperClassName],
-            arrow_num,
+            arrow_count[*SuperClassNameStd],
             true,
             false, "", "" );
           ItemMap[ClassName]->AddArrow ( NewArrow );
@@ -278,7 +279,7 @@ QStringList dbse::SchemaGraphicsScene::AddItemsToScene (
           //NewArrow->SetLabelScene(this);
           NewArrow->setZValue ( -1000.0 );
           NewArrow->UpdatePosition();
-          arrow_num++;
+          arrow_count[*SuperClassNameStd]++;
         }
       }
     }

--- a/apps/SchemaEditor/SchemaGraphicsScene.cpp
+++ b/apps/SchemaEditor/SchemaGraphicsScene.cpp
@@ -2,7 +2,7 @@
 #include <QGraphicsSceneDragDropEvent>
 #include <QMimeData>
 #include <QWidget>
-#include <QPainter>
+
 #include <QMenu>
 #include <QApplication>
 /// Including Schema Editor
@@ -225,6 +225,7 @@ QStringList dbse::SchemaGraphicsScene::AddItemsToScene (
       ClassInfo->direct_relationships();
     const std::list<std::string *> * DirectSuperClassesList = ClassInfo->direct_super_classes();
 
+    int arrow_num=0;
     //// PLotting relationships
     if ( DirectRelationshipList != nullptr )
     {
@@ -233,13 +234,15 @@ QStringList dbse::SchemaGraphicsScene::AddItemsToScene (
         QString RelationshipClassType = QString::fromStdString (
                                           ClassRelationship->get_class_type()->get_name() );
 
-        if ( ItemMap.contains ( RelationshipClassType ) && !ItemMap[ClassName]->HasArrow (
-               ItemMap[RelationshipClassType] ) )
+        if ( ItemMap.contains ( RelationshipClassType ) ) //&& !ItemMap[ClassName]->HasArrow (
+          //ItemMap[RelationshipClassType] ) )
         {
           QString SchemaCardinality =
-            KernelWrapper::GetInstance().GetCardinalityStringRelationship ( ClassRelationship );
+            KernelWrapper::GetInstance().GetCardinalityStringRelationship ( ClassRelationship ) + " ";
           SchemaGraphicSegmentedArrow * NewArrow = new SchemaGraphicSegmentedArrow (
-            ItemMap[ClassName], ItemMap[RelationshipClassType], false,
+            ItemMap[ClassName], ItemMap[RelationshipClassType],
+            arrow_num,
+            false,
             ClassRelationship->get_is_composite(),
             QString::fromStdString ( ClassRelationship->get_name() ), SchemaCardinality );
           ItemMap[ClassName]->AddArrow ( NewArrow );
@@ -248,6 +251,7 @@ QStringList dbse::SchemaGraphicsScene::AddItemsToScene (
           //NewArrow->SetLabelScene(this);
           NewArrow->setZValue ( -1000.0 );
           NewArrow->UpdatePosition();
+          arrow_num++;
         }
       }
     }
@@ -259,12 +263,15 @@ QStringList dbse::SchemaGraphicsScene::AddItemsToScene (
       {
         QString SuperClassName = QString::fromStdString ( *SuperClassNameStd );
 
-        if ( ItemMap.contains ( SuperClassName ) && !ItemMap[ClassName]->HasArrow (
-               ItemMap[SuperClassName] ) )
+        if ( ItemMap.contains ( SuperClassName ) ) // && !ItemMap[ClassName]->HasArrow (
+          // ItemMap[SuperClassName] ) )
         {
-          SchemaGraphicSegmentedArrow * NewArrow = new SchemaGraphicSegmentedArrow ( ItemMap[ClassName],
-                                                                   ItemMap[SuperClassName], true,
-                                                                   false, "", "" );
+          SchemaGraphicSegmentedArrow * NewArrow = new SchemaGraphicSegmentedArrow (
+            ItemMap[ClassName],
+            ItemMap[SuperClassName],
+            arrow_num,
+            true,
+            false, "", "" );
           ItemMap[ClassName]->AddArrow ( NewArrow );
           ItemMap[SuperClassName]->AddArrow ( NewArrow );
           addItem ( NewArrow );
@@ -368,8 +375,11 @@ void dbse::SchemaGraphicsScene::mouseReleaseEvent ( QGraphicsSceneMouseEvent * m
       {
         startItem->GetClass()->add_super_class ( endItem->GetClassName().toStdString() );
         /// Create arrow
-        SchemaGraphicSegmentedArrow * newArrow = new SchemaGraphicSegmentedArrow ( startItem, endItem, Inheritance,
-                                                                 true, "", "" );
+        SchemaGraphicSegmentedArrow * newArrow = new SchemaGraphicSegmentedArrow (
+          startItem, endItem,
+          0,
+          Inheritance,
+          true, "", "" );
         startItem->AddArrow ( newArrow );
         endItem->AddArrow ( newArrow );
         newArrow->setZValue ( -1000.0 );
@@ -578,7 +588,9 @@ void dbse::SchemaGraphicsScene::DrawArrow ( QString ClassName, QString Relations
     QString RelationshipCardinality =
       KernelWrapper::GetInstance().GetCardinalityStringRelationship ( SchemaRelationship );
     SchemaGraphicSegmentedArrow * newArrow = new SchemaGraphicSegmentedArrow (
-      startItem, endItem, false, SchemaRelationship->get_is_composite(),
+      startItem, endItem,
+      0,
+      false, SchemaRelationship->get_is_composite(),
       QString::fromStdString ( SchemaRelationship->get_name() ), RelationshipCardinality );
     startItem->AddArrow ( newArrow );
     endItem->AddArrow ( newArrow );

--- a/apps/SchemaEditor/SchemaGraphicsScene.cpp
+++ b/apps/SchemaEditor/SchemaGraphicsScene.cpp
@@ -17,7 +17,7 @@ using namespace dunedaq::oks;
 
 dbse::SchemaGraphicsScene::SchemaGraphicsScene ( QObject * parent )
   : QGraphicsScene ( parent ),
-    line ( nullptr ),
+    m_line ( nullptr ),
     m_context_menu ( nullptr ),
     CurrentObject ( nullptr ),
     m_current_arrow ( nullptr ),
@@ -318,9 +318,9 @@ void dbse::SchemaGraphicsScene::mousePressEvent ( QGraphicsSceneMouseEvent * mou
 
   if ( mouseEvent->widget()->cursor().shape() == Qt::CrossCursor )
   {
-    line = new QGraphicsLineItem ( QLineF ( mouseEvent->scenePos(), mouseEvent->scenePos() ) );
-    line->setPen ( QPen ( Qt::black, 2 ) );
-    addItem ( line );
+    m_line = new QGraphicsLineItem ( QLineF ( mouseEvent->scenePos(), mouseEvent->scenePos() ) );
+    m_line->setPen ( QPen ( Qt::black, 2 ) );
+    addItem ( m_line );
     return;
   }
 
@@ -329,37 +329,38 @@ void dbse::SchemaGraphicsScene::mousePressEvent ( QGraphicsSceneMouseEvent * mou
 
 void dbse::SchemaGraphicsScene::mouseMoveEvent ( QGraphicsSceneMouseEvent * mouseEvent )
 {
-  if ( line != nullptr )
+  if ( m_line != nullptr )
   {
-    QLineF newLine ( line->line().p1(), mouseEvent->scenePos() );
-    line->setLine ( newLine );
+    QLineF newLine ( m_line->line().p1(), mouseEvent->scenePos() );
+    m_line->setLine ( newLine );
   }
   else
   {
     QGraphicsScene::mouseMoveEvent ( mouseEvent );
   }
+  m_modified = true;
 }
 
 void dbse::SchemaGraphicsScene::mouseReleaseEvent ( QGraphicsSceneMouseEvent * mouseEvent )
 {
-  if ( line != nullptr )
+  if ( m_line != nullptr )
   {
-    QList<QGraphicsItem *> startItems = items ( line->line().p1() );
+    QList<QGraphicsItem *> startItems = items ( m_line->line().p1() );
 
-    if ( startItems.count() && startItems.first() == line )
+    if ( startItems.count() && startItems.first() == m_line )
     {
       startItems.removeFirst();
     }
 
-    QList<QGraphicsItem *> endItems = items ( line->line().p2() );
+    QList<QGraphicsItem *> endItems = items ( m_line->line().p2() );
 
-    if ( endItems.count() && endItems.first() == line )
+    if ( endItems.count() && endItems.first() == m_line )
     {
       endItems.removeFirst();
     }
 
-    RemoveItemFromScene ( line );
-    delete line;
+    RemoveItemFromScene ( m_line );
+    delete m_line;
 
     if ( startItems.count() > 0 && endItems.count() > 0
          && startItems.first() != endItems.first() )
@@ -398,7 +399,7 @@ void dbse::SchemaGraphicsScene::mouseReleaseEvent ( QGraphicsSceneMouseEvent * m
     }
   }
 
-  line = nullptr;
+  m_line = nullptr;
   QGraphicsScene::mouseReleaseEvent ( mouseEvent );
 }
 

--- a/apps/SchemaEditor/SchemaGraphicsScene.cpp
+++ b/apps/SchemaEditor/SchemaGraphicsScene.cpp
@@ -278,6 +278,7 @@ QStringList dbse::SchemaGraphicsScene::AddItemsToScene (
           //NewArrow->SetLabelScene(this);
           NewArrow->setZValue ( -1000.0 );
           NewArrow->UpdatePosition();
+          arrow_num++;
         }
       }
     }

--- a/apps/SchemaEditor/SchemaMainWindow.cpp
+++ b/apps/SchemaEditor/SchemaMainWindow.cpp
@@ -238,6 +238,13 @@ void dbse::SchemaMainWindow::SetSchemaFileActive()
   QModelIndex Index = ui->FileView->currentIndex();
   QStringList Row = FileModel->getRowFromIndex ( Index );
   KernelWrapper::GetInstance().SetActiveSchema ( Row.at ( 0 ).toStdString() );
+
+  // In case we are highlighting classes in the active file, redraw current
+  // view tab now we've changed active file
+  SchemaTab * current_tab = dynamic_cast<SchemaTab *> ( ui->TabWidget->currentWidget() );
+  SchemaGraphicsScene * scene = current_tab->GetScene();
+  scene->update();
+
   BuildFileModel();
 }
 void dbse::SchemaMainWindow::SaveSchemaFile()

--- a/apps/SchemaEditor/SchemaMainWindow.cpp
+++ b/apps/SchemaEditor/SchemaMainWindow.cpp
@@ -160,16 +160,23 @@ void dbse::SchemaMainWindow::BuildTableModel()
 
 int dbse::SchemaMainWindow::ShouldSaveViewChanges() const
 {
+  QString modified_views;
   for (int index=0; index<ui->TabWidget->count(); ++index) {
     auto tab = dynamic_cast<SchemaTab *> (ui->TabWidget->widget(index));
     if (tab->GetScene()->IsModified()) {
-      return QMessageBox::question (
-        0, tr ( "SchemaEditor" ),
-        QString ( "There are unsaved changes in the schema views:\n"
-                  "Do you want to save the changes in the schema views?\n" ),
-        QMessageBox::Discard | QMessageBox::Cancel, QMessageBox::Discard );
+      modified_views.append(tab->getName() + "\n");
     }
   }
+  if (!modified_views.isEmpty()) {
+    QString message ( "There are unsaved changes in the schema views:\n");
+    message.append (modified_views);
+    message.append ("Do you want to save the changes in the schema views?\n" );
+    return QMessageBox::question (
+      0, tr ( "SchemaEditor" ),
+      message,
+      QMessageBox::Discard | QMessageBox::Cancel, QMessageBox::Discard );
+  }
+
   return QMessageBox::Discard;
 }
 

--- a/include/dbe/SchemaGraphicObject.hpp
+++ b/include/dbe/SchemaGraphicObject.hpp
@@ -3,6 +3,7 @@
 
 /// Including QT Headers
 #include <QGraphicsObject>
+#include <QGraphicsSceneHoverEvent>
 #include <QFont>
 #include <QColor>
 #include <QPen>
@@ -26,6 +27,7 @@ public:
   void GetInfo();
   /// Graphic API
   void set_inherited_properties_visibility( bool visible );
+  void set_highlight_active( bool highlight );
   QRectF boundingRect() const;
   QPainterPath shape() const;
   void paint ( QPainter * painter, const QStyleOptionGraphicsItem * option,
@@ -37,6 +39,9 @@ public:
   bool HasArrow ( SchemaGraphicObject * Dest ) const;
 protected:
   QVariant itemChange ( GraphicsItemChange change, const QVariant & value );
+  void hoverEnterEvent ( QGraphicsSceneHoverEvent* ev );
+  void hoverLeaveEvent ( QGraphicsSceneHoverEvent* ev );
+  void mouseDoubleClickEvent ( QGraphicsSceneMouseEvent* ev );
 private:
   dunedaq::oks::OksClass * m_class_info;
   QString m_class_object_name;
@@ -49,6 +54,7 @@ private:
   QStringList m_class_inherited_methods;
 
   bool m_inherited_properties_visible;  
+  bool m_highlight_active{false};
   QFont m_font;
   QFont m_bold_font;
   QColor m_default_color;

--- a/include/dbe/SchemaGraphicSegmentedArrow.hpp
+++ b/include/dbe/SchemaGraphicSegmentedArrow.hpp
@@ -14,6 +14,7 @@ class SchemaGraphicSegmentedArrow: public QGraphicsPathItem
 {
 public:
   SchemaGraphicSegmentedArrow ( SchemaGraphicObject * StartItem, SchemaGraphicObject * EndItem,
+                                int connection_count,
                        bool IsInheritance, bool IsComposite, QString ArrowName,
                        QString ArrowCardinality, QGraphicsItem * parent = nullptr );
   ~SchemaGraphicSegmentedArrow();
@@ -39,6 +40,7 @@ private:
 
   SchemaGraphicObject * m_start_item;
   SchemaGraphicObject * m_end_item;
+  int m_connection_count;
   QPolygonF m_marker;
   QRectF m_rel_label_br;
   QRectF m_rel_cardinality_br;

--- a/include/dbe/SchemaGraphicSegmentedArrow.hpp
+++ b/include/dbe/SchemaGraphicSegmentedArrow.hpp
@@ -28,6 +28,8 @@ public:
 protected:
   void paint ( QPainter * painter, const QStyleOptionGraphicsItem * option,
                QWidget * widget = 0 );
+  void hoverEnterEvent ( QGraphicsSceneHoverEvent* ev );
+  void hoverLeaveEvent ( QGraphicsSceneHoverEvent* ev );
 private:
 
   QPointF p1() const { return path().elementCount() > 0 ? path().elementAt(0) : QPointF(); }

--- a/include/dbe/SchemaGraphicsScene.hpp
+++ b/include/dbe/SchemaGraphicsScene.hpp
@@ -48,7 +48,7 @@ private slots:
   void DrawArrow ( QString ClassName, QString RelationshipType, QString RelationshipName );
 private:
   QMap<QString, SchemaGraphicObject *> ItemMap;
-  QGraphicsLineItem * line;
+  QGraphicsLineItem * m_line;
   QMenu * m_context_menu;
   QAction * AddClass;
   QAction * EditClass;

--- a/include/dbe/SchemaGraphicsScene.hpp
+++ b/include/dbe/SchemaGraphicsScene.hpp
@@ -30,6 +30,7 @@ public:
   [[nodiscard]] bool IsModified () const {return m_modified;};
   void ClearModified() {m_modified = false;};
 protected:
+  // bool event ( QEvent* event );
   void mousePressEvent ( QGraphicsSceneMouseEvent * mouseEvent );
   void mouseMoveEvent ( QGraphicsSceneMouseEvent * mouseEvent );
   void mouseReleaseEvent ( QGraphicsSceneMouseEvent * mouseEvent );
@@ -38,6 +39,7 @@ private slots:
   void AddClassSlot();
   void EditClassSlot();
   void ToggleIndirectInfos();
+  void ToggleHighlightActive();
   void AddDirectSuperClassesSlot();
   void AddAllSuperClassesSlot();
   void AddAllSubClassesSlot();
@@ -53,6 +55,7 @@ private:
   QAction * AddClass;
   QAction * EditClass;
   QAction * m_toggle_indirect_infos;
+  QAction * m_toggle_highlight_active;
   QAction * m_add_direct_super_classes;
   QAction * m_add_direct_relationship_classes;
   QAction * m_add_all_super_classes;
@@ -64,6 +67,7 @@ private:
   SchemaGraphicSegmentedArrow * m_current_arrow;
 
   bool m_inherited_properties_visible;
+  bool m_highlight_active;
   bool m_modified;
 };
 

--- a/include/dbe/SchemaMainWindow.hpp
+++ b/include/dbe/SchemaMainWindow.hpp
@@ -35,6 +35,7 @@ private:
   QMenu * ContextMenuFileView;
   QMenu * ContextMenuTableView;
   QString Title{"DUNE DAQ Configuration Schema editor"};
+  QString m_view_dir{"."};
   void InitialSettings();
   void InitialTab();
   void InitialTabCorner();


### PR DESCRIPTION
Fix for issue #38, draw all arrows between 2 classes, trying to separate them enough to be readable.

Also includes a couple of other changes:

- Have view save/load operations remember last directory used and offer as default.
- Add option to highlight classes from active schema