### PR TITLE
Johnfreeman/issue45 unit test fix

### DIFF
--- a/schema/dbe/dbe_unittest.data.xml
+++ b/schema/dbe/dbe_unittest.data.xml
@@ -68,7 +68,7 @@
 <info name="" type="" num-of-items="2" oks-format="data" oks-version="N/A" created-by="jcfree" created-on="mu2edaq13.fnal.gov" creation-time="20230105T194746" last-modified-by="jcfree" last-modified-on="mu2edaq13.fnal.gov" last-modification-time="20230105T194746"/>
 
 <include>
- <file path="core.schema.xml"/>
+ <file path="schema/dbe/core.schema.xml"/>
 </include>
 
 <obj class="Partition" id="ToyPartition">

--- a/unittest/config_api_set_test.cxx
+++ b/unittest/config_api_set_test.cxx
@@ -61,7 +61,13 @@ BOOST_AUTO_TEST_CASE(unset_multi_relation)
 		
 		dunedaq::conffwk::relationship_t relation = info::relation::match(relation_to_modify, aclass);
 		BOOST_CHECK_EQUAL(relation_to_modify,relation.p_name );
-		BOOST_CHECK_NO_THROW(set::noactions::relation(oref, relation , empty));
+
+		try {
+		  set::noactions::relation(oref, relation, empty);
+		} catch (const ers::Issue& e) {
+		  ers:error(e);
+		  BOOST_FAIL("Error: ERS exception thrown from relation function");
+		}
 	}
 }
 


### PR DESCRIPTION
I'm able to reproduce the error described in Issue #45 *if* I `spack load dbe` and then don't run either of `dbt-workarea-env` or `source ./env.sh`. While Boost's `BOOST_CHECK_NO_THROW` macro is "slick", it hides a lot of information if something does go wrong and a throw actually occurs, so what this feature branch does is at least reveal what the problem is. 

Spoiler alert: what you're going to see is something like this:
```
2025-Aug-21 11:10:30,918 ERROR [dbe::config::api::set::noactions::relation(...) at /home/nfs/jcfree/NFD_DEV_250821_A9/sourcecode/dbe/src/internal/config_api_set.cpp:75] oks[1] ***: Failed to set relationship 'Segments' of object "ToyOnlineSegment@OnlineSegment"oks[0] ***: Failed to lock file '/cvmfs/dunedaq-development.opensciencegrid.org/nightly/NB_DEV_250821_A9/spack-0.22.0/opt/spack/linux-almalinux9-x86_64/gcc-13.2.0/dbe-NB_DEV_250821_A9-kwxhxmjo2dfenqhzm35ehvsfsitcc7wy/share/schema/dbe/dbe_unittest.data.xml' because:file is read-only
```