### PR TITLE
Johnfreeman/merge prep release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(dbe VERSION 1.6.0)
+project(dbe VERSION 1.6.1)
 
 find_package(daq-cmake REQUIRED)
 

--- a/schema/dbe/dbe_unittest.data.xml
+++ b/schema/dbe/dbe_unittest.data.xml
@@ -68,7 +68,7 @@
 <info name="" type="" num-of-items="2" oks-format="data" oks-version="N/A" created-by="jcfree" created-on="mu2edaq13.fnal.gov" creation-time="20230105T194746" last-modified-by="jcfree" last-modified-on="mu2edaq13.fnal.gov" last-modification-time="20230105T194746"/>
 
 <include>
- <file path="core.schema.xml"/>
+ <file path="schema/dbe/core.schema.xml"/>
 </include>
 
 <obj class="Partition" id="ToyPartition">

--- a/unittest/config_api_set_test.cxx
+++ b/unittest/config_api_set_test.cxx
@@ -61,7 +61,13 @@ BOOST_AUTO_TEST_CASE(unset_multi_relation)
 		
 		dunedaq::conffwk::relationship_t relation = info::relation::match(relation_to_modify, aclass);
 		BOOST_CHECK_EQUAL(relation_to_modify,relation.p_name );
-		BOOST_CHECK_NO_THROW(set::noactions::relation(oref, relation , empty));
+
+		try {
+		  set::noactions::relation(oref, relation, empty);
+		} catch (const ers::Issue& e) {
+		  ers:error(e);
+		  BOOST_FAIL("Error: ERS exception thrown from relation function");
+		}
 	}
 }
 


### PR DESCRIPTION
The `johnfreeman/merge_prep-release` branch is an intermediary intended to de-facto merge the `prep-release/fddaq-v5.4.0` branch into `develop`.  A test build was successfully performed earlier today (`MRG2FD_DEV_250903_A9`) and integration tests were successful (https://github.com/DUNE-DAQ/daq-release/actions/runs/17444202007).