### PR TITLE
Protect against nullptr when getting class from relationship or superclass

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(dbe VERSION 1.7.0)
+project(dbe VERSION 1.7.1)
 
 find_package(daq-cmake REQUIRED)
 

--- a/apps/SchemaEditor/SchemaFileInfo.cpp
+++ b/apps/SchemaEditor/SchemaFileInfo.cpp
@@ -126,7 +126,21 @@ bool SchemaFileInfo::check_relationships(dunedaq::oks::OksClass* cls) {
   auto relationships = cls->direct_relationships();
   if (relationships != nullptr) {
     for (auto rel: *relationships) {
-      auto file = rel->get_class_type()->get_file()->get_full_file_name();
+      auto rel_class = rel->get_class_type();
+      if (rel_class == nullptr) {
+        QString warning = "<b>Warning</b> class <i>"
+          + QString::fromStdString(cls->get_name())
+          + "</i> has relationship "
+          + QString::fromStdString(rel->get_name())
+          + " referring to class <i>"
+          + QString::fromStdString(rel->get_type())
+          + "</i> which is not loaded<br>";
+        m_ui->textBrowser->insertHtml(warning);
+        m_ui->textBrowser->show();
+        ok = false;
+        continue;
+      }
+      auto file = rel_class->get_file()->get_full_file_name();
       if (file != m_filename && !m_all_includes.contains(file)) {
         m_missing_includes.insert(file);
         QString warning = "<b>Warning</b> class <i>"
@@ -152,6 +166,16 @@ bool SchemaFileInfo::check_superclasses(dunedaq::oks::OksClass* cls) {
   if (super_classes != nullptr) {
     for (auto sc: *super_classes) {
       auto sclass = KernelWrapper::GetInstance().FindClass(*sc);
+      if (sclass == nullptr) {
+        QString warning = "<b>Warning</b> class <i>"
+          + QString::fromStdString(cls->get_name())
+          + "</i> refers to super class <i>" + QString::fromStdString(*sc)
+          + "</i> which is not known<br>";
+        m_ui->textBrowser->insertHtml(warning);
+        m_ui->textBrowser->show();
+        ok = false;
+        continue;
+      }
       auto file = sclass->get_file()->get_full_file_name();
       if (file != m_filename && !m_all_includes.contains(file)) {
         m_missing_includes.insert(file);


### PR DESCRIPTION
# Description

While investigating problem with appmodel/PDS.schema.xml found that schemaeditor would crash when trying to open file info window. This was because PDS.schema.xml referred to a class from a schema file that was not loaded at all. Now the check for missing include files checks for nullptr returns from `get_class_type()` and `FindClass()` and sets appropriate warning text rather than crashing.

Can be tested by opening PDS.schema.xml from appmodel v4.0.0 and double clicking on PDS.schema.xml file name in file view or with another schema file that has objects with superclass or relatiomship classes that are not in any included file.


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

