### PR TITLE
Gcrone/check files

### DIFF
--- a/apps/SchemaEditor/SchemaFileInfo.cpp
+++ b/apps/SchemaEditor/SchemaFileInfo.cpp
@@ -104,9 +104,11 @@ void SchemaFileInfo::get_includes() {
   KernelWrapper::GetInstance().get_direct_includes(m_filename, direct_includes);
 
   for (auto inc: m_all_includes) {
-    auto item = new QListWidgetItem(QString::fromStdString(inc));
+    auto file = prune_path(inc);
+    auto item = new QListWidgetItem(QString::fromStdString(file));
+    item->setToolTip(QString::fromStdString(inc));
     m_ui->include_list->addItem(item);
-    if (!direct_includes.contains(prune_path(inc))) {
+    if (!direct_includes.contains(file)) {
       item->setForeground(QBrush(SchemaStyle::get_color("foreground", "inherited")));
     }
     else if (!KernelWrapper::GetInstance().IsFileWritable (inc)) {
@@ -356,7 +358,12 @@ void SchemaFileInfo::show_status() {
   }
   if (KernelWrapper::GetInstance().is_file_modified ( m_filename )) {
     status.append("  Modified");
-    m_ui->save_button->setEnabled(true);
+    if (m_missing_includes.empty()) {
+      m_ui->save_button->setEnabled(true);
+    }
+    else {
+      m_ui->save_button->setEnabled(false);
+    }
   }
   else {
     m_ui->save_button->setEnabled(false);

--- a/apps/SchemaEditor/SchemaKernelWrapper.cpp
+++ b/apps/SchemaEditor/SchemaKernelWrapper.cpp
@@ -178,9 +178,9 @@ OksClass * dbse::KernelWrapper::FindClass ( std::string ClassName ) const
   return Kernel->find_class ( ClassName );
 }
 
-void dbse::KernelWrapper::LoadSchema ( const std::string & SchemaName ) const
+OksFile* dbse::KernelWrapper::LoadSchema ( const std::string & SchemaName ) const
 {
-  Kernel->load_schema ( SchemaName );
+  return Kernel->load_schema ( SchemaName );
 }
 
 void dbse::KernelWrapper::SaveAllSchema() const

--- a/apps/SchemaEditor/SchemaMainWindow.cpp
+++ b/apps/SchemaEditor/SchemaMainWindow.cpp
@@ -339,7 +339,92 @@ void dbse::SchemaMainWindow::SetSchemaFileActive()
   BuildFileModel();
 }
 
+bool dbse::SchemaMainWindow::check_schema_file(QString qfilename){
+  std::string filename = qfilename.toStdString();
+  std::set<std::string> includes;
+  KernelWrapper::GetInstance().get_all_includes(filename, includes);
+
+  QString advice{"<br><br>Use the File info window to fix the problem."};
+  for (auto cls: KernelWrapper::GetInstance().get_schema_classes(filename)) {
+    auto relationships = cls->direct_relationships();
+    if (relationships != nullptr) {
+      for (auto rel: *relationships) {
+        auto rel_class = rel->get_class_type();
+        if (rel_class == nullptr) {
+          QString warning = "<b>Warning</b> class <i>"
+            + QString::fromStdString(cls->get_name())
+            + "</i> has relationship "
+            + QString::fromStdString(rel->get_name())
+            + " referring to class <i>"
+            + QString::fromStdString(rel->get_type())
+            + "</i> which is not loaded<br>";
+          QMessageBox::warning(0,
+                               "Check Schema",
+                               warning+advice,
+                               QMessageBox::Ok);
+          show_file_info(qfilename);
+          return false;
+        }
+        auto file = rel_class->get_file()->get_full_file_name();
+        if (file != filename && !includes.contains(file)) {
+          QString warning = "<b>Warning</b> class <i>"
+            + QString::fromStdString(cls->get_name())
+            + "</i> has relationship "
+            + QString::fromStdString(rel->get_name())
+            + " referring to class <i>"
+            + QString::fromStdString(rel->get_class_type()->get_name())
+            + "</i> from " + QString::fromStdString(file)
+            + " which is not included by " + qfilename;
+          QMessageBox::warning(0,
+                               "Check Schema",
+                               warning+advice,
+                               QMessageBox::Ok);
+          show_file_info(qfilename);
+          return false;
+        }
+      }
+    }
+
+    auto super_classes = cls->direct_super_classes();
+    if (super_classes != nullptr) {
+      for (auto sc: *super_classes) {
+        auto sclass = KernelWrapper::GetInstance().FindClass(*sc);
+        if (sclass == nullptr) {
+          QString warning = "<b>Warning</b> class <i>"
+            + QString::fromStdString(cls->get_name())
+            + "</i> refers to super class <i>" + QString::fromStdString(*sc)
+            + "</i> which is not known<br>";
+          QMessageBox::warning(0,
+                               "Check Schema",
+                               warning+advice,
+                               QMessageBox::Ok);
+          show_file_info(qfilename);
+          return false;
+        }
+        auto file = sclass->get_file()->get_full_file_name();
+        if (file != filename && !includes.contains(file)) {
+          QString warning = "<b>Warning</b> class <i>"
+            + QString::fromStdString(cls->get_name())
+            + "</i> refers to super class <i>" + QString::fromStdString(*sc)
+            + "</i> from " + QString::fromStdString(file)
+            + " which is not included by" + qfilename;
+          QMessageBox::warning(0,
+                               "Check Schema",
+                               warning+advice,
+                               QMessageBox::Ok);
+          show_file_info(qfilename);
+          return false;
+        }
+      }
+    }
+  }
+  return true;
+}
+
 bool dbse::SchemaMainWindow::save_schema_file(QString filename){
+  if (!check_schema_file(filename)) {
+    return false;
+  }
   bool status;
   QString message;
   try {
@@ -417,7 +502,10 @@ void dbse::SchemaMainWindow::closeEvent ( QCloseEvent * event )
 
   if ( UserChoice == QMessageBox::Save )
   {
-    SaveModifiedSchema();
+    if (!SaveModifiedSchema()) {
+      event->ignore();
+      return;
+    }
   }
   else if ( UserChoice == QMessageBox::Cancel )
   {
@@ -448,9 +536,10 @@ void dbse::SchemaMainWindow::update_models() {
 }
 
 void dbse::SchemaMainWindow::OpenSchemaFile(QString SchemaFile) {
+  OksFile* file{nullptr};
   if(!SchemaFile.isEmpty()) {
     try {
-      KernelWrapper::GetInstance().LoadSchema(SchemaFile.toStdString());
+      file = KernelWrapper::GetInstance().LoadSchema(SchemaFile.toStdString());
 
       if (m_schema_directory == QString(".")) {
         std::vector<std::string> fnames; 
@@ -488,6 +577,9 @@ void dbse::SchemaMainWindow::OpenSchemaFile(QString SchemaFile) {
     update_window_title(QFileInfo(SchemaFile).fileName());
     //ui->CreateNewSchema->setDisabled (true );
     //ui->OpenFileSchema->setDisabled (true );
+    if (file != nullptr) {
+      check_schema_file(QString::fromStdString(file->get_full_file_name()));
+    }
   }
 }
 
@@ -521,12 +613,17 @@ void dbse::SchemaMainWindow::OpenSchemaFile()
 
   OpenSchemaFile(SchemaPath);
 }
-void dbse::SchemaMainWindow::SaveModifiedSchema()
+
+bool dbse::SchemaMainWindow::SaveModifiedSchema()
 {
+  bool result = true;
   for (auto file: KernelWrapper::GetInstance().get_modified_schema_files()) {
-    save_schema_file(QString::fromStdString(file));
+    if (!save_schema_file(QString::fromStdString(file))) {
+      result = false;
+    }
   }
   BuildFileModel();
+  return result;
 }
 
 void dbse::SchemaMainWindow::SaveSchema()

--- a/include/dbe/SchemaKernelWrapper.hpp
+++ b/include/dbe/SchemaKernelWrapper.hpp
@@ -16,6 +16,7 @@ namespace dunedaq {
   namespace oks {
     class OksKernel;
     class OksClass;
+    class OksFile;
   }
 }
 
@@ -52,7 +53,7 @@ public:
   bool is_file_modified ( const std::string & FileName ) const;
   bool IsActive() const;
   dunedaq::oks::OksClass * FindClass ( std::string ClassName ) const;
-  void LoadSchema ( const std::string & SchemaName ) const;
+  dunedaq::oks::OksFile* LoadSchema ( const std::string & SchemaName ) const;
   void SaveAllSchema() const;
   void SaveSchema ( const std::string& file ) const;
   std::vector<std::string> get_modified_schema_files() const;

--- a/include/dbe/SchemaMainWindow.hpp
+++ b/include/dbe/SchemaMainWindow.hpp
@@ -53,6 +53,7 @@ private:
   void write_view_file(const QString& fn, SchemaTab* tab);
   [[nodiscard]] int ShouldSaveChanges() const;
   [[nodiscard]] int ShouldSaveViewChanges() const;
+  bool check_schema_file(QString file);
   bool save_schema_file(QString file);
 protected:
   void closeEvent ( QCloseEvent * event );
@@ -73,7 +74,7 @@ private slots:
   void SaveSchema();
   // From FileView 
   void SaveSchemaFile();
-  void SaveModifiedSchema();
+  bool SaveModifiedSchema();
   void ChangeCursorRelationship ( bool State );
   void ChangeCursorInheritance ( bool State );
   void add_tab();


### PR DESCRIPTION
# Description

Introduce consistency checks when loading and more importantly saving schema files from the `schemaeditor`.

Previous versions of `schemaeditor` would allow files to be saved with dangling references to classes from schema files which were not included.

Addresses issue https://github.com/DUNE-DAQ/daq-deliverables/issues/203

## To test

1.  Open `schemaeditor` with an existing schema file e.g. schema/confmodel/dunedaq.schema.xml.
2.  Then create a new schema file (Ctrl-N or select option from File menu).
3.  Create a new class (Ctrl-A) in the new schema file and either set it to inherit from an existing class or add a relationship to an existing class.
4.  Try to save the file (Ctrl-S or from context menu in file tab) or exit with (Ctrl-Q and select the save button). A modal dialogue box  should appear warning you of a problem. On dismissing the dialogue a file info window should appear allowing you to adjust the list of included files. 
5. Add the file containing the referenced class
6. Try step 4 again

Trying steps 1-4 with an older version of `schemaeditor` would allow saving the file with its inconsistencies. Loading such a file with this version should also raise the warning dialogue box.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

